### PR TITLE
changes prolinux base/appstream repo from 8 to 8.2

### DIFF
--- a/templates/user-data.j2
+++ b/templates/user-data.j2
@@ -15,7 +15,7 @@ timezone: {{ he_time_zone }}
 {% endif %}
 bootcmd:
 {% if he_prolinux_repo_address is not none and he_prolinux_repo_address|length > 1 %}
-  - sed -i 's#http://prolinux-repo.tmaxos.com/prolinux/8/os/x86_64#{{ he_prolinux_repo_address }}#g' /etc/yum.repos.d/ProLinux.repo
+  - sed -i 's#http://prolinux-repo.tmaxos.com/prolinux/8.2/os/x86_64#{{ he_prolinux_repo_address }}#g' /etc/yum.repos.d/ProLinux.repo
 {% endif %}
 {% if he_ovirt_repo_address is not none and he_ovirt_repo_address|length > 1 %}
   - sed -i 's#http://prolinux-repo.tmaxos.com/ovirt/4.4/el8/x86_64#{{ he_ovirt_repo_address }}#g' /etc/yum.repos.d/ovirt.repo


### PR DESCRIPTION
- ovirt-engine-appliance에서 기본으로 설정된 ProLinux repository 주소를 "http://prolinux-repo.tmaxos.com/prolinux/8/os/x86_64/" 에서 "http://prolinux-repo.tmaxos.com/prolinux/8.2/os/x86_64/"로 수정하여 HostedEngine을 띄울 때 해당 주소를 치환할 수 있도록 변경